### PR TITLE
🔨 Fix for async call without await

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,4 +144,9 @@ export async function renderTemplate(templatePath: string, destPath: string, dat
   }
 }
 
-main();
+
+const asyncMain = async () => {
+    await main();
+};
+
+asyncMain();

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,4 +149,8 @@ const asyncMain = async () => {
     await main();
 };
 
-asyncMain();
+asyncMain().catch(error => {
+    if (error instanceof Error) {
+        logger.error(`An Error occured: ${error.stack}`);
+    }
+});


### PR DESCRIPTION
### Motivation and Context

Static analysis tool flags this as an error. Also it caused problems when running test that don't terminate and to be forced shut. And lacks error handling

### Description

fixes static analysis flagging the lack of await on async call for main by
- Wrapping the call to async main function, and adding await
- Adds catch and log error's stack

I did not simply add a top level await because it causes problems with certain typescript configs 